### PR TITLE
Use LinearSolve.jl for RBF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
           - 'nightly'
         os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 1.0
-  - 1.1
-  - 1.2
+  - 1.6
+  - 1.7
   - nightly
 matrix:
   allow_failures:

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 Combinatorics = "1"
 Distances = "0.9,0.10"
 NearestNeighbors = "0.4"
-julia = "1"
+julia = "1.6"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/Project.toml
+++ b/Project.toml
@@ -7,11 +7,13 @@ Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
+LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 
 [compat]
 Combinatorics = "1"
 Distances = "0.9,0.10"
 NearestNeighbors = "0.4"
+LinearSolve = "1"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -17,8 +17,7 @@ LinearSolve = "1"
 julia = "1.6"
 
 [extras]
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random"]
+test = ["Test"]

--- a/src/ScatteredInterpolation.jl
+++ b/src/ScatteredInterpolation.jl
@@ -1,6 +1,6 @@
 module ScatteredInterpolation
 
-using Distances, NearestNeighbors, Combinatorics, LinearAlgebra
+using Distances, NearestNeighbors, Combinatorics, LinearAlgebra, LinearSolve
 
 export interpolate,
     evaluate

--- a/test/rbf.jl
+++ b/test/rbf.jl
@@ -40,15 +40,17 @@ radialBasisFunctions = (Gaussian(2),
         @test r.(data) ≈ f.(data)
 
         offset = 2e-4
-        for points in (arrayPoints, adjointPoints)
-            itp = interpolate(r, points, data)
+        for linsolve in (nothing, IterativeSolversJL_GMRES())
+            for points in (arrayPoints, adjointPoints)
+                itp = interpolate(r, points, data; linsolve = linsolve)
 
-            # Check that we get back the original data at the sample points and that we get
-            # close when evaluating near the sampling points
-            ev = evaluate(itp, points)
-            @test ev ≈ data
-            ev = evaluate(itp, points .+ offset)
-            @test all(isapprox.(data, ev, atol = 1e-2))
+                # Check that we get back the original data at the sample points and that we get
+                # close when evaluating near the sampling points
+                ev = evaluate(itp, points)
+                @test ev ≈ data
+                ev = evaluate(itp, points .+ offset)
+                @test all(isapprox.(data, ev, atol = 1e-2))
+            end
         end
     end
 

--- a/test/rbf.jl
+++ b/test/rbf.jl
@@ -39,6 +39,7 @@ radialBasisFunctions = (Gaussian(2),
 
         @test r.(data) ≈ f.(data)
 
+        offset = 2e-4
         for points in (arrayPoints, adjointPoints)
             itp = interpolate(r, points, data)
 
@@ -46,7 +47,7 @@ radialBasisFunctions = (Gaussian(2),
             # close when evaluating near the sampling points
             ev = evaluate(itp, points)
             @test ev ≈ data
-            ev = evaluate(itp, points .+ 0.001*randn(size(points)))
+            ev = evaluate(itp, points .+ offset)
             @test all(isapprox.(data, ev, atol = 1e-2))
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using ScatteredInterpolation, Test
+using ScatteredInterpolation, Test, LinearSolve
 
 include("rbf.jl")
 include("idw.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,4 @@
-using ScatteredInterpolation, Random
-
-Random.seed!(2)
-
-if VERSION < v"0.7-"
-    using Base.Test
-else
-    using Test
-end
+using ScatteredInterpolation, Test
 
 include("rbf.jl")
 include("idw.jl")


### PR DESCRIPTION
Adds an option to specify solvers from LinearSolve.jl when solving for the weights in RBF interpolation.