### PR TITLE
Sparse interpolation for compactly supported RBFs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 OhMyThreads = "67456a42-1dca-4109-a031-0a68de7e3ad5"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
@@ -20,6 +21,7 @@ KernelFunctions = "0.11"
 LinearSolve = "2"
 NearestNeighbors = "0.4"
 OhMyThreads = "0.8"
+SparseArrays = "1"
 Statistics = "1"
 julia = "1.10"
 

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 OhMyThreads = "67456a42-1dca-4109-a031-0a68de7e3ad5"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Combinatorics = "1"
@@ -19,6 +20,7 @@ KernelFunctions = "0.11"
 LinearSolve = "2"
 NearestNeighbors = "0.4"
 OhMyThreads = "0.8"
+Statistics = "1"
 julia = "1.10"
 
 [extras]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -27,6 +27,17 @@ GeneralizedPolyharmonic
 Wendland
 ```
 
+### Compactly supported RBFs (sparse path)
+
+[`Wendland`](@ref) is the only compactly supported basis function, and the only one
+eligible for the `sparse` interpolation path — see [Compactly supported RBFs and the
+sparse path](@ref) for the full picture of the `sparse`/`neighbors` keywords, the
+``r = 1/\varepsilon`` relation, and the accuracy/sparsity trade-off.
+
+```@docs
+CompactSupportRBFInterpolant
+```
+
 ### Partition of Unity
 
 ```@docs

--- a/docs/src/methods.md
+++ b/docs/src/methods.md
@@ -224,6 +224,80 @@ The chosen algorithm is reused across every right-hand side needed for a given
 `interpolate` call (multiple sample columns, and, for generalized RBFs, the polynomial
 and Schur-complement solves), so the factorization is only computed once per matrix.
 
+## Compactly supported RBFs and the sparse path
+
+Every basis function above is evaluated at every pairwise distance, so the RBF
+interpolation matrix is dense in general. [`Wendland`](@ref) is the exception: it is a
+*compactly supported* kernel, identically zero beyond its support radius, and
+`interpolate` can exploit that to build and factorize a sparse matrix instead of a
+dense one.
+
+| Kernel | Support | `sparse` eligible |
+|--------|---------|-------------------|
+| [`Wendland`](@ref) | Compact: zero for ``r > 1/\varepsilon`` | Yes |
+| [`Gaussian`](@ref), [`Multiquadratic`](@ref), [`InverseQuadratic`](@ref), [`InverseMultiquadratic`](@ref), [`Polyharmonic`](@ref)/[`ThinPlate`](@ref), [`GeneralizedMultiquadratic`](@ref), [`GeneralizedPolyharmonic`](@ref) | Global: nonzero at all distances | No |
+
+A globally supported kernel is nonzero at every distance — its interpolation matrix
+has no zero entries, so `sparse` is mathematically meaningless for it, and
+`sparse = true` throws an error. For local behavior with globally supported kernels,
+use [`PartitionOfUnity`](@ref) instead.
+
+### Support radius and `ε`
+
+A Wendland kernel's shape parameter `ε` sets its support radius directly:
+```math
+ϕ(r) = 0 \quad \text{for} \quad r > 1/\varepsilon
+```
+so a larger `ε` means a smaller support radius, and vice versa.
+
+`ε` can also be left unset on construction (`Wendland(dim, degree)`, with no `ε`).
+In that case `interpolate` calibrates it from the training data: `1/ε` is set to the
+median distance to the `neighbors`-th nearest neighbor, sampled over a subset of the
+training points. Passing `ε` explicitly always takes precedence, in which case
+`neighbors` is ignored.
+
+This `neighbors` resolves something different from SciPy's `neighbors` keyword.
+SciPy's `RBFInterpolator(neighbors=k)` solves a small local system per query point —
+an approximation to the full interpolant. Here, `neighbors` only calibrates the
+cutoff radius of the kernel used in one exact global system; it never changes what
+is being solved. For the local-system approach analogous to SciPy's `neighbors`, use
+[`PartitionOfUnity`](@ref).
+
+### Sparsity, accuracy and conditioning
+
+A small support radius (large `ε`) produces a sparser, faster-to-factorize system,
+but sacrifices accuracy: data points outside each other's support do not interact at
+all, so the interpolant can only capture behavior at the scale of `1/ε`. A large
+support (small `ε`) gives accuracy approaching a dense global solve but loses the
+sparsity benefit — and, as with any RBF, a support radius (or `ε`) chosen badly
+relative to the point spacing can also leave the system ill-conditioned. For very
+large datasets where even a sparse global system is too expensive,
+[`PartitionOfUnity`](@ref) remains the primary method.
+
+Query points that fall outside the support of every training point evaluate to
+exactly zero. This is the mathematically correct value of the interpolant there, not
+an approximation or a missing-data placeholder.
+
+### Choosing `sparse` and the linear solver
+
+`sparse` (default `:auto`) controls whether `interpolate` takes the sparse path:
+`:auto` uses it when the problem is large and the resulting matrix sufficiently
+sparse, `true` forces it (throwing if the kernel or metric makes sparsity
+impossible, e.g. a globally supported kernel), and `false` always uses the dense
+path.
+
+The default solver for the sparse path is `CHOLMODFactorization()` from
+[LinearSolve.jl](https://docs.sciml.ai/LinearSolve/stable/), which exploits the
+symmetric positive definite structure of the Wendland interpolation matrix. As with
+the dense path, this can be overridden with the `linsolve` keyword, e.g.
+`linsolve = KrylovJL_CG()` for a matrix-free iterative solve on very large problems:
+
+```julia
+using LinearSolve
+
+itp = interpolate(Wendland(3, 1), points, samples; linsolve = KrylovJL_CG())
+```
+
 ## Inverse Distance Weighting
 Also called Shepard interpolation, the basic version computes the interpolated value at
 some point ``\mathbf{x}`` by

--- a/docs/src/methods.md
+++ b/docs/src/methods.md
@@ -218,7 +218,7 @@ itp = interpolate(rbf, points, samples; linsolve = LUFactorization())
 matrix type. Any concrete algorithm from LinearSolve.jl's
 [solver list](https://docs.sciml.ai/LinearSolve/stable/solvers/solvers/) can be passed,
 e.g. `QRFactorization()` for a more numerically robust (but slower) solve of an
-ill-conditioned system, or `KrylovJL_GMRES()` for large, sparse, or matrix-free problems.
+ill-conditioned system, or `KrylovJL_GMRES()` for large, sparse problems.
 
 The chosen algorithm is reused across every right-hand side needed for a given
 `interpolate` call (multiple sample columns, and, for generalized RBFs, the polynomial
@@ -290,7 +290,7 @@ The default solver for the sparse path is `CHOLMODFactorization()` from
 [LinearSolve.jl](https://docs.sciml.ai/LinearSolve/stable/), which exploits the
 symmetric positive definite structure of the Wendland interpolation matrix. As with
 the dense path, this can be overridden with the `linsolve` keyword, e.g.
-`linsolve = KrylovJL_CG()` for a matrix-free iterative solve on very large problems:
+`linsolve = KrylovJL_CG()` for an iterative solve on very large problems:
 
 ```julia
 using LinearSolve

--- a/src/ScatteredInterpolation.jl
+++ b/src/ScatteredInterpolation.jl
@@ -33,7 +33,7 @@ function evaluate(itp::ScatteredInterpolant, points::AbstractArray{<:Real, 1})
 end
 
 """
-    interpolate(method, points, samples; metric = Euclidean(), returnRBFmatrix = false, smooth = false, linsolve = nothing)
+    interpolate(method, points, samples; metric = Euclidean(), returnRBFmatrix = false, smooth = false, linsolve = nothing, sparse = :auto, neighbors = 50)
 
 Create an interpolation of the data in `samples` sampled at the locations defined in
 `points` based on the interpolation method `method`. `metric` is any of the metrics defined
@@ -60,6 +60,18 @@ values. Note that it is no longer interpolating when using smoothing.
 
 The returned `ScatteredInterpolant` object can be passed to `evaluate` to interpolate the
 data to new points.
+
+For compactly supported basis functions (`Wendland`), `sparse` controls a sparse
+interpolation path that assembles only the nonzero entries of the RBF matrix and
+solves with sparse Cholesky (`CHOLMODFactorization`): `:auto` (default) uses it when
+the problem is large and the matrix sufficiently sparse, `true` forces it (erroring
+if the kernel or metric makes sparsity impossible), `false` always uses the dense
+path. Globally supported kernels (Gaussian, Multiquadratic, …) are nonzero at every
+distance and can never be sparse — use `PartitionOfUnity` for locality with those.
+
+A `Wendland` kernel constructed without `ε` gets its support radius from the data:
+`1/ε` is set to the median distance to the `neighbors`-th nearest neighbor. An
+explicit `ε` always wins, in which case `neighbors` is ignored.
 """
 function interpolate end
 

--- a/src/ScatteredInterpolation.jl
+++ b/src/ScatteredInterpolation.jl
@@ -3,6 +3,8 @@ module ScatteredInterpolation
 using Distances, NearestNeighbors, Combinatorics, LinearAlgebra, LinearSolve
 using OhMyThreads: tmap, index_chunks
 using Statistics: median
+using SparseArrays: sparse, SparseMatrixCSC, nnz
+import SparseArrays
 import KernelFunctions
 
 export interpolate,
@@ -14,6 +16,7 @@ abstract type InterpolationMethod end
 include("./rbf.jl")
 include("./rippa.jl")
 include("./wendland.jl")
+include("./csrbf.jl")
 include("./pum.jl")
 include("./idw.jl")
 include("./nearestNeighbor.jl")

--- a/src/ScatteredInterpolation.jl
+++ b/src/ScatteredInterpolation.jl
@@ -2,6 +2,7 @@ module ScatteredInterpolation
 
 using Distances, NearestNeighbors, Combinatorics, LinearAlgebra, LinearSolve
 using OhMyThreads: tmap, index_chunks
+using Statistics: median
 import KernelFunctions
 
 export interpolate,

--- a/src/csrbf.jl
+++ b/src/csrbf.jl
@@ -137,24 +137,25 @@ function assemblesparse(rbf, points::AbstractMatrix{<:Real}, tree, metric, smoot
     r = support_radius(rbf)
     Tv = typeof(rbf(zero(float(eltype(points)))))
 
-    Is = Int[]
-    Js = Int[]
-    Vs = Tv[]
-
-    for i in 1:n
-        xi = view(points, :, i)
-        for j in inrange(tree, xi, r)
-            v = rbf(metric(xi, view(points, :, j)))
-            if j == i && smooth !== false
-                v += smoothvalue(smooth, i)
+    chunks = index_chunks(1:n; n = 8 * Threads.nthreads())
+    parts = tmap(chunks) do rng
+        Is = Int[]; Js = Int[]; Vs = Tv[]
+        for i in rng
+            xi = view(points, :, i)
+            for j in inrange(tree, xi, r)
+                v = rbf(metric(xi, view(points, :, j)))
+                if j == i && smooth !== false
+                    v += smoothvalue(smooth, i)
+                end
+                push!(Is, i); push!(Js, j); push!(Vs, v)
             end
-            push!(Is, i)
-            push!(Js, j)
-            push!(Vs, v)
         end
+        (Is, Js, Vs)
     end
 
-    sparse(Is, Js, Vs, n, n)
+    sparse(reduce(vcat, p[1] for p in parts),
+           reduce(vcat, p[2] for p in parts),
+           reduce(vcat, p[3] for p in parts), n, n)
 end
 
 """
@@ -196,14 +197,22 @@ function evaluate(itp::CompactSupportRBFInterpolant, points::AbstractArray{<:Rea
     m = size(points, 2)
     r = support_radius(itp.rbf)
     Tv = typeof(itp.rbf(zero(float(eltype(points)))))
-    Is = Int[]; Js = Int[]; Vs = Tv[]
-    for q in 1:m
-        xq = view(points, :, q)
-        for j in inrange(itp.tree, xq, r)
-            push!(Is, q); push!(Js, j)
-            push!(Vs, itp.rbf(itp.metric(xq, view(itp.points, :, j))))
+
+    chunks = index_chunks(1:m; n = 8 * Threads.nthreads())
+    parts = tmap(chunks) do rng
+        Is = Int[]; Js = Int[]; Vs = Tv[]
+        for q in rng
+            xq = view(points, :, q)
+            for j in inrange(itp.tree, xq, r)
+                push!(Is, q); push!(Js, j)
+                push!(Vs, itp.rbf(itp.metric(xq, view(itp.points, :, j))))
+            end
         end
+        (Is, Js, Vs)
     end
-    Φ = sparse(Is, Js, Vs, m, n)
+
+    Φ = sparse(reduce(vcat, p[1] for p in parts),
+               reduce(vcat, p[2] for p in parts),
+               reduce(vcat, p[3] for p in parts), m, n)
     Φ * itp.w
 end

--- a/src/csrbf.jl
+++ b/src/csrbf.jl
@@ -84,7 +84,32 @@ function interpolatecsrbf(rbf, points, samples, tree, metric, smooth, linsolve,
     returnRBFmatrix ? (itp, A) : itp
 end
 
-# NOTE: `evaluate` for `CompactSupportRBFInterpolant` is intentionally not defined here.
-# A correct implementation needs the same tree-based range-query sparsity as
-# `assemblesparse` (a dense `pairwise` evaluate would defeat the point of this whole
-# module); that is left to a follow-up task alongside its own tests.
+"""
+    evaluate(itp::CompactSupportRBFInterpolant, points)
+
+Evaluate the interpolant at `points` (dimension × number of query points). For each
+query point, a KDTree range query over `itp.tree` (radius `support_radius(itp.rbf)`)
+finds the training points that can contribute; only those pairs are evaluated and
+assembled into a sparse Φ, so points with no in-range neighbors evaluate to exactly
+zero rather than requiring a dense pairwise distance matrix.
+"""
+function evaluate(itp::CompactSupportRBFInterpolant, points::AbstractArray{<:Real, 2})
+    size(points, 1) == size(itp.points, 1) || throw(DimensionMismatch(
+        "query points have dimension $(size(points, 1)) but the interpolant was " *
+        "built for dimension $(size(itp.points, 1))"))
+
+    n = size(itp.points, 2)
+    m = size(points, 2)
+    r = support_radius(itp.rbf)
+    Tv = typeof(itp.rbf(zero(float(eltype(points)))))
+    Is = Int[]; Js = Int[]; Vs = Tv[]
+    for q in 1:m
+        xq = view(points, :, q)
+        for j in inrange(itp.tree, xq, r)
+            push!(Is, q); push!(Js, j)
+            push!(Vs, itp.rbf(itp.metric(xq, view(itp.points, :, j))))
+        end
+    end
+    Φ = sparse(Is, Js, Vs, m, n)
+    Φ * itp.w
+end

--- a/src/csrbf.jl
+++ b/src/csrbf.jl
@@ -6,14 +6,14 @@
 
 export CompactSupportRBFInterpolant
 
-# Routing thresholds for the `sparse = :auto` decision in `interpolate` (rbf.jl):
-# below SPARSE_MIN_POINTS the dense path is cheap enough that assembling and
-# factorizing a sparse matrix is not worth it; above it, a sampled fill estimate
-# (fraction of nonzero entries, from FILL_SAMPLE_SIZE probe points) above
-# SPARSE_MAX_FILL means the support radius is wide enough that the matrix is nearly
-# dense anyway, so the dense path is used instead.
+# Routing thresholds for the `sparse = :auto` decision in `interpolate` (rbf.jl).
+# Calibrated on d = 2 golden-ratio lattice, 2026-07-06:
+#   n-crossover: sparse wins at all n ≥ 500 with low fill (0.005s vs 0.008s at n=500,
+#                43× at n=10000). SPARSE_MIN_POINTS = 500 confirmed.
+#   fill-crossover at n = 10000: sparse wins up to ~6% fill (ε=7, 4.2s vs 9.6s),
+#                loses at ~11% (ε=5, 41s vs 9.7s). SPARSE_MAX_FILL set to 0.07.
 const SPARSE_MIN_POINTS = 500
-const SPARSE_MAX_FILL = 0.25
+const SPARSE_MAX_FILL = 0.07
 const FILL_SAMPLE_SIZE = 32
 
 """

--- a/src/csrbf.jl
+++ b/src/csrbf.jl
@@ -1,0 +1,90 @@
+# Sparse assembly and solve for compactly supported radial basis functions (currently
+# Wendland; any RBF with a finite `support_radius` could use this path). Distances
+# beyond the support radius are never computed: a KDTree range query restricts the
+# assembly to the pairs that actually contribute, giving a genuinely sparse matrix
+# instead of a dense one filled mostly with zeros.
+
+export CompactSupportRBFInterpolant
+
+"""
+    CompactSupportRBFInterpolant
+
+Interpolant produced by [`interpolate`](@ref) for a compactly supported radial basis
+function (e.g. [`Wendland`](@ref)). Holds the solved weights `w`, the training
+`points`, the `rbf` kernel, the `metric` used to compute distances, and the `tree`
+(a `NearestNeighbors.KDTree`) used for the sparse assembly and reused by `evaluate`.
+"""
+struct CompactSupportRBFInterpolant{T1 <: AbstractArray, T2 <: AbstractMatrix{<:Real},
+                                    F, M, KT} <: RadialBasisInterpolant
+    w::T1
+    points::T2
+    rbf::F
+    metric::M
+    tree::KT
+end
+
+# Smoothing (ridge regression) value for point i: a scalar applies uniformly, a vector
+# gives one value per point. Mirrors addSmoothing!'s dispatch in rbf.jl.
+smoothvalue(smooth::Number, i) = smooth
+smoothvalue(smooth::AbstractVector, i) = smooth[i]
+
+"""
+    assemblesparse(rbf, points, tree, metric, smooth)
+
+Assemble the sparse compactly-supported RBF interpolation matrix. For each point `i`,
+a KDTree range query over `tree` (radius `support_radius(rbf)`) finds the columns `j`
+for which `rbf` is potentially nonzero, and only those entries are evaluated and
+stored — pairs outside the support radius are never computed. `smooth` is added to the
+diagonal (scalar applies to every point, a vector gives one value per point; `false`
+adds nothing).
+"""
+function assemblesparse(rbf, points::AbstractMatrix{<:Real}, tree, metric, smooth)
+    n = size(points, 2)
+    r = support_radius(rbf)
+    Tv = typeof(rbf(zero(float(eltype(points)))))
+
+    Is = Int[]
+    Js = Int[]
+    Vs = Tv[]
+
+    for i in 1:n
+        xi = view(points, :, i)
+        for j in inrange(tree, xi, r)
+            v = rbf(metric(xi, view(points, :, j)))
+            if j == i && smooth !== false
+                v += smoothvalue(smooth, i)
+            end
+            push!(Is, i)
+            push!(Js, j)
+            push!(Vs, v)
+        end
+    end
+
+    sparse(Is, Js, Vs, n, n)
+end
+
+"""
+    interpolatecsrbf(rbf, points, samples, tree, metric, smooth, linsolve, returnRBFmatrix)
+
+Assemble the sparse compactly-supported RBF matrix and solve for the interpolation
+weights via a sparse Cholesky factorization (`LinearSolve.CHOLMODFactorization`, unless
+`linsolve` overrides it). Returns a [`CompactSupportRBFInterpolant`](@ref), or a
+`(itp, A)` tuple when `returnRBFmatrix` is `true`.
+"""
+function interpolatecsrbf(rbf, points, samples, tree, metric, smooth, linsolve,
+                          returnRBFmatrix)
+    A = assemblesparse(rbf, points, tree, metric, smooth)
+
+    alg = linsolve === nothing ? CHOLMODFactorization() : linsolve
+    cache = _initsolve(A, alg)
+    w = _solve!(cache, samples)
+
+    itp = CompactSupportRBFInterpolant(w, points, rbf, metric, tree)
+
+    returnRBFmatrix ? (itp, A) : itp
+end
+
+# NOTE: `evaluate` for `CompactSupportRBFInterpolant` is intentionally not defined here.
+# A correct implementation needs the same tree-based range-query sparsity as
+# `assemblesparse` (a dense `pairwise` evaluate would defeat the point of this whole
+# module); that is left to a follow-up task alongside its own tests.

--- a/src/csrbf.jl
+++ b/src/csrbf.jl
@@ -6,6 +6,16 @@
 
 export CompactSupportRBFInterpolant
 
+# Routing thresholds for the `sparse = :auto` decision in `interpolate` (rbf.jl):
+# below SPARSE_MIN_POINTS the dense path is cheap enough that assembling and
+# factorizing a sparse matrix is not worth it; above it, a sampled fill estimate
+# (fraction of nonzero entries, from FILL_SAMPLE_SIZE probe points) above
+# SPARSE_MAX_FILL means the support radius is wide enough that the matrix is nearly
+# dense anyway, so the dense path is used instead.
+const SPARSE_MIN_POINTS = 500
+const SPARSE_MAX_FILL = 0.25
+const FILL_SAMPLE_SIZE = 32
+
 """
     CompactSupportRBFInterpolant
 
@@ -27,6 +37,90 @@ end
 # gives one value per point. Mirrors addSmoothing!'s dispatch in rbf.jl.
 smoothvalue(smooth::Number, i) = smooth
 smoothvalue(smooth::AbstractVector, i) = smooth[i]
+
+"""
+    decidesparse(sparse, rbf, points, metric, tree)
+
+Resolve the `sparse` kwarg of `interpolate` (`:auto`, `true` or `false`) into a
+concrete `(usesparse::Bool, tree)` decision. `tree` is the `KDTree` built by
+`resolveshape` when a Wendland ε needed resolving, or `nothing`; it is built here
+(and returned for reuse by the caller) only when actually needed for the decision or
+the subsequent sparse assembly.
+
+`sparse = true` throws an `ArgumentError` (via [`sparseineligibility`](@ref)) when the
+kernel or metric makes a sparse solve impossible. `sparse = :auto` falls back to the
+dense path instead of throwing, and additionally requires at least
+`SPARSE_MIN_POINTS` points and an estimated matrix fill (via
+[`estimatefill`](@ref)) below `SPARSE_MAX_FILL`.
+"""
+function decidesparse(sparse, rbf, points, metric, tree)
+    sparse === false && return (false, tree)
+    sparse === true || sparse === :auto || throw(ArgumentError(
+        "sparse must be :auto, true or false, got $(repr(sparse))"))
+
+    reason = sparseineligibility(rbf, metric)
+    if sparse === true
+        reason === nothing || throw(ArgumentError(reason))
+    else
+        reason === nothing || return (false, tree)
+        size(points, 2) >= SPARSE_MIN_POINTS || return (false, tree)
+    end
+
+    tree = tree === nothing ? KDTree(points, metric) : tree
+    if sparse === :auto &&
+       estimatefill(tree, points, support_radius(rbf)) > SPARSE_MAX_FILL
+        return (false, tree)
+    end
+    (true, tree)
+end
+
+"""
+    sparseineligibility(rbf, metric)
+
+Return a human-readable reason `String` why `rbf`/`metric` cannot go through the
+sparse interpolation path, or `nothing` if they can. Used by
+[`decidesparse`](@ref).
+"""
+function sparseineligibility(rbf, metric)
+    if rbf isa AbstractVector
+        return "sparse interpolation does not support a vector of per-point " *
+               "kernels: there is no single support radius"
+    elseif rbf isa GeneralizedRadialBasisFunction
+        return "sparse interpolation does not support generalized " *
+               "(polynomial-augmented) RBFs: the augmented system is not sparse " *
+               "positive definite"
+    elseif !isfinite(support_radius(rbf))
+        return "$(nameof(typeof(rbf))) is globally supported (nonzero at every " *
+               "distance), so its interpolation matrix has no zero entries and " *
+               "cannot be sparse. Use a compactly supported kernel (Wendland) for " *
+               "a sparse global solve, or PartitionOfUnity for locality with " *
+               "this kernel"
+    elseif !(metric isa Distances.MinkowskiMetric)
+        return "sparse interpolation requires a Minkowski-family metric " *
+               "(Euclidean, Cityblock, Chebyshev or Minkowski) for the KDTree " *
+               "range search, got $(nameof(typeof(metric)))"
+    end
+    nothing
+end
+
+"""
+    estimatefill(tree, points, r)
+
+Estimate the fraction of nonzero entries the sparse RBF matrix would have, by
+sampling up to `FILL_SAMPLE_SIZE` points and averaging the fraction of `points` that
+fall within radius `r` of each (via a KDTree range query over `tree`). Used by
+[`decidesparse`](@ref) to fall back to the dense path when the support radius is wide
+enough that the matrix would be nearly dense anyway.
+"""
+function estimatefill(tree, points, r)
+    n = size(points, 2)
+    sample = round.(Int, range(1, n; length = min(n, FILL_SAMPLE_SIZE)))
+    total = 0
+    for i in sample
+        total += length(inrange(tree, view(points, :, i), r))
+    end
+    total / (length(sample) * n)
+end
 
 """
     assemblesparse(rbf, points, tree, metric, smooth)

--- a/src/pum.jl
+++ b/src/pum.jl
@@ -426,7 +426,7 @@ function interpolate(pum::PartitionOfUnity, points::AbstractArray{<:Real, 2},
     grid = buildgrid(pts, pum.pointsperpatch, pum.overlap)
     tree = KDTree(pts)
     patchpoints, centers = assignpatches(pts, grid, tree)
-    weight = pum.weight === nothing ? Wendland(d, 1) : pum.weight
+    weight = pum.weight === nothing ? Wendland(d, 1; ε = 1) : pum.weight
 
     # Patches near the boundary of the data can end up with few, one-sided points
     # (their ball sticks out of the data region), and a starved local interpolant

--- a/src/rbf.jl
+++ b/src/rbf.jl
@@ -230,10 +230,20 @@ function interpolate(rbf::Union{T, AbstractVector{T}} where T <: AbstractRadialB
                      samples::AbstractArray{<:Number,N};
                      metric = Euclidean(), returnRBFmatrix::Bool = false,
                      smooth::Union{S, AbstractVector{S}} = false,
-                     linsolve = nothing) where {N} where {S<:Number}
+                     linsolve = nothing,
+                     sparse = :auto,
+                     neighbors::Integer = 50) where {N} where {S<:Number}
 
-    #hinder smooth from being set to true and interpreted as the value 1 
+    #hinder smooth from being set to true and interpreted as the value 1
     @assert smooth != true "set the smoothing value as a number or vector of numbers"
+
+    rbf, tree = resolveshape(rbf, points, metric, neighbors)
+
+    usesparse, tree = decidesparse(sparse, rbf, points, metric, tree)
+    if usesparse
+        return interpolatecsrbf(rbf, points, samples, tree, metric, smooth,
+                                linsolve, returnRBFmatrix)
+    end
 
     # Compute pairwise distances, apply the Radial Basis Function
     # and optional smoothing (ridge regression)

--- a/src/wendland.jl
+++ b/src/wendland.jl
@@ -4,7 +4,7 @@
 export Wendland
 
 """
-    Wendland(dim, degree; ε = 1)
+    Wendland(dim, degree; ε = nothing)
 
 Define a compactly supported Wendland Radial Basis Function. The resulting kernel is
 positive definite for data of dimension up to `dim`, is `2*degree` times continuously
@@ -19,25 +19,37 @@ degree ``v``. The kernel evaluation is provided by
 `KernelFunctions.PiecewisePolynomialKernel`; see its documentation for the exact
 coefficients. For `dim` ∈ {2, 3} and `degree = 1` this is the classic C² function
 ``ϕ(r) = (1 - εr)_+^4 (4εr + 1)``.
+
+`ε` may be omitted (or passed explicitly as `nothing`), leaving the shape parameter
+unset. An unset `ε` cannot be evaluated or queried for `support_radius` directly; it
+must first be resolved from data via `resolveshape` (used internally by `interpolate`
+with the `neighbors` keyword), which sets `ε` to the reciprocal of the median distance
+to each point's `neighbors`-th nearest neighbor.
 """
-struct Wendland{K <: KernelFunctions.PiecewisePolynomialKernel, T <: Real} <: RadialBasisFunction
+struct Wendland{K <: KernelFunctions.PiecewisePolynomialKernel,
+                T <: Union{Real, Nothing}} <: RadialBasisFunction
     kernel::K
     ε::T
 end
 
-function Wendland(dim::Integer, degree::Integer; ε::Real = 1)
+function Wendland(dim::Integer, degree::Integer; ε::Union{Real, Nothing} = nothing)
     0 <= degree <= 3 || throw(ArgumentError(
         "Wendland degree must be 0, 1, 2 or 3, got $degree"))
     dim >= 1 || throw(ArgumentError(
         "Wendland dim must be a positive integer, got $dim"))
-    ε > 0 || throw(ArgumentError(
+    ε === nothing || ε > 0 || throw(ArgumentError(
         "Wendland shape parameter ε must be positive, got $ε"))
 
     kernel = KernelFunctions.PiecewisePolynomialKernel(; degree = Int(degree), dim = Int(dim))
     Wendland(kernel, ε)
 end
 
-(w::Wendland)(r) = KernelFunctions.kappa(w.kernel, w.ε * r)
+const _unsetShapeMessage = "this Wendland kernel has no shape parameter yet; pass ε " *
+    "to the constructor or let interpolate resolve it from the data via the " *
+    "neighbors keyword"
+
+(w::Wendland{<:Any, <:Real})(r) = KernelFunctions.kappa(w.kernel, w.ε * r)
+(w::Wendland{<:Any, Nothing})(r) = throw(ArgumentError(_unsetShapeMessage))
 
 """
     support_radius(rbf)
@@ -47,7 +59,8 @@ functions. A finite support radius is the dispatch hook for a future sparse-asse
 interpolation path (see the RBF-PUM design spec, Future Work).
 """
 support_radius(::AbstractRadialBasisFunction) = Inf
-support_radius(w::Wendland) = 1 / w.ε
+support_radius(w::Wendland{<:Any, <:Real}) = 1 / w.ε
+support_radius(::Wendland{<:Any, Nothing}) = throw(ArgumentError(_unsetShapeMessage))
 
 # The wrapped PiecewisePolynomialKernel does not depend on ε (ε is applied outside it,
 # in kappa(kernel, ε*r)), so a re-shaped Wendland reuses it directly — dim and degree
@@ -55,3 +68,35 @@ support_radius(w::Wendland) = 1 / w.ε
 # public constructor's ε > 0 check is not needed here.
 hasshape(::Wendland) = true
 withshape(w::Wendland, ε) = Wendland(w.kernel, ε)
+
+"""
+    resolveshape(rbf, points, metric, neighbors)
+
+Resolve an unset shape parameter from the data, returning `(rbf, tree)`. `tree` is the
+`KDTree` built to answer the nearest-neighbor query (reused by callers that need it
+afterwards, e.g. for a sparse assembly path), or `nothing` when no query was needed.
+
+The fallback method (any `rbf` other than a `Wendland` with unset `ε`) returns the
+`rbf` unchanged and `tree = nothing`.
+"""
+resolveshape(rbf, points, metric, neighbors) = (rbf, nothing)
+
+function resolveshape(w::Wendland{<:Any, Nothing}, points, metric, neighbors)
+    metric isa Distances.MinkowskiMetric || throw(ArgumentError(
+        "resolving Wendland ε from the data requires a Minkowski-family metric " *
+        "(Euclidean, Cityblock, Chebyshev or Minkowski); pass ε explicitly instead"))
+    neighbors >= 1 || throw(ArgumentError(
+        "neighbors must be at least 1, got $neighbors"))
+
+    n = size(points, 2)
+    tree = KDTree(points, metric)
+    k = min(neighbors + 1, n)
+    sample = round.(Int, range(1, n; length = min(n, 100)))
+    _, dists = knn(tree, points[:, sample], k)
+    r = median(maximum.(dists))
+    r > 0 || throw(ArgumentError(
+        "cannot resolve a Wendland support radius: sampled neighbor distances are " *
+        "all zero (duplicate points?); pass ε explicitly"))
+
+    (withshape(w, 1 / r), tree)
+end

--- a/test/csrbf.jl
+++ b/test/csrbf.jl
@@ -48,4 +48,28 @@ csrbfKernel = Wendland(2, 1; ε = 4.0)   # support radius 0.25 ⇒ genuinely spa
             csrbfKernel, csrbfPoints, multi, tree, Euclidean(), false, nothing, false)
         @test itpm.w[:, 2] ≈ 2 .* itpm.w[:, 1] atol = 1e-8
     end
+
+    @testset "Neighbor-only evaluation" begin
+        tree = ScatteredInterpolation.NearestNeighbors.KDTree(csrbfPoints, Euclidean())
+        itp = ScatteredInterpolation.interpolatecsrbf(
+            csrbfKernel, csrbfPoints, csrbfData, tree, Euclidean(), false, nothing, false)
+
+        # Exact at the data points.
+        @test evaluate(itp, csrbfPoints) ≈ csrbfData atol = 1e-8
+
+        # Matches the dense path on an off-node query grid.
+        dense = interpolate(csrbfKernel, csrbfPoints, csrbfData)
+        grid = permutedims(reduce(vcat, [x y] for x in 0.05:0.1:0.95, y in 0.05:0.1:0.95))
+        @test evaluate(itp, grid) ≈ evaluate(dense, grid) atol = 1e-8
+
+        # Identically zero outside every kernel's support (radius 0.25, data in the
+        # unit square, query at distance > 1 from the square).
+        @test all(iszero, evaluate(itp, reshape([5.0, 5.0], 2, 1)))
+
+        # Vector query goes through the generic reshape fallback.
+        @test evaluate(itp, [0.5, 0.5]) ≈ evaluate(dense, [0.5, 0.5]) atol = 1e-8
+
+        # Wrong dimension errors.
+        @test_throws DimensionMismatch evaluate(itp, reshape([0.5], 1, 1))
+    end
 end

--- a/test/csrbf.jl
+++ b/test/csrbf.jl
@@ -72,4 +72,76 @@ csrbfKernel = Wendland(2, 1; ε = 4.0)   # support radius 0.25 ⇒ genuinely spa
         # Wrong dimension errors.
         @test_throws DimensionMismatch evaluate(itp, reshape([0.5], 1, 1))
     end
+
+    @testset "interpolate sparse routing" begin
+        # 600 deterministic points: above SPARSE_MIN_POINTS.
+        bigPoints = permutedims(reduce(vcat,
+            [mod(0.618034 * i, 1.0)  mod(0.414214 * i, 1.0)] for i in 1:600))
+        bigData = vec(sin.(2π .* bigPoints[1, :]))
+        w4 = Wendland(2, 1; ε = 4.0)
+
+        itpS = interpolate(w4, bigPoints, bigData; sparse = true)
+        itpD = interpolate(w4, bigPoints, bigData; sparse = false)
+        @test itpS isa ScatteredInterpolation.CompactSupportRBFInterpolant
+        @test itpD isa ScatteredInterpolation.RBFInterpolant
+        grid = permutedims(reduce(vcat, [x y] for x in 0.05:0.1:0.95, y in 0.05:0.1:0.95))
+        @test evaluate(itpS, grid) ≈ evaluate(itpD, grid) atol = 1e-8
+
+        # :auto — big n, small support ⇒ sparse; small n ⇒ dense; huge support ⇒ dense.
+        @test interpolate(w4, bigPoints, bigData) isa
+            ScatteredInterpolation.CompactSupportRBFInterpolant
+        @test interpolate(w4, csrbfPoints, csrbfData) isa
+            ScatteredInterpolation.RBFInterpolant
+        @test interpolate(Wendland(2, 1; ε = 0.1), bigPoints, bigData) isa
+            ScatteredInterpolation.RBFInterpolant   # support radius 10 ⇒ full matrix
+
+        # sparse = true impossibilities.
+        @test_throws ArgumentError interpolate(Gaussian(), bigPoints, bigData; sparse = true)
+        err = try interpolate(Multiquadratic(), bigPoints, bigData; sparse = true)
+        catch e; e end
+        @test occursin("PartitionOfUnity", err.msg) && occursin("Wendland", err.msg)
+        @test_throws ArgumentError interpolate(
+            GeneralizedMultiquadratic(1, 1/2, 2), bigPoints, bigData; sparse = true)
+        @test_throws ArgumentError interpolate(
+            fill(w4, size(bigPoints, 2)), bigPoints, bigData; sparse = true)
+        @test_throws ArgumentError interpolate(
+            w4, bigPoints, bigData; sparse = true, metric = Haversine())
+        @test_throws ArgumentError interpolate(w4, bigPoints, bigData; sparse = :bogus)
+
+        # returnRBFmatrix on the sparse path.
+        _, A = interpolate(w4, bigPoints, bigData; sparse = true, returnRBFmatrix = true)
+        @test A isa ScatteredInterpolation.SparseArrays.SparseMatrixCSC
+
+        # smooth forwards.
+        itpSm = interpolate(w4, bigPoints, bigData; sparse = true, smooth = 0.1)
+        itpDm = interpolate(w4, bigPoints, bigData; sparse = false, smooth = 0.1)
+        @test evaluate(itpSm, grid) ≈ evaluate(itpDm, grid) atol = 1e-8
+
+        # linsolve override (CG on the SPD sparse system).
+        itpCG = interpolate(w4, bigPoints, bigData; sparse = true,
+                            linsolve = LinearSolve.KrylovJL_CG())
+        @test evaluate(itpCG, grid) ≈ evaluate(itpD, grid) atol = 1e-6
+
+        # Deferred ε flows through interpolate; neighbors moves the radius.
+        itpAuto = interpolate(Wendland(2, 1), bigPoints, bigData)
+        @test ScatteredInterpolation.support_radius(itpAuto.rbf) < Inf
+        itpWide = interpolate(Wendland(2, 1), bigPoints, bigData; neighbors = 200)
+        @test ScatteredInterpolation.support_radius(itpWide.rbf) >
+              ScatteredInterpolation.support_radius(itpAuto.rbf)
+        # Unset ε also works when forced dense.
+        @test interpolate(Wendland(2, 1), csrbfPoints, csrbfData; sparse = false) isa
+            ScatteredInterpolation.RBFInterpolant
+
+        # Complex samples: parity with the dense path.
+        cdata = csrbfData .+ im .* reverse(csrbfData)
+        denseC = try interpolate(csrbfKernel, csrbfPoints, cdata; sparse = false)
+        catch e; e end
+        sparseC = try interpolate(csrbfKernel, csrbfPoints, cdata; sparse = true)
+        catch e; e end
+        if denseC isa Exception
+            @test sparseC isa Exception
+        else
+            @test evaluate(sparseC, grid) ≈ evaluate(denseC, grid) atol = 1e-8
+        end
+    end
 end

--- a/test/csrbf.jl
+++ b/test/csrbf.jl
@@ -1,0 +1,51 @@
+# Self-contained test data (do not reuse variables leaked from other test files).
+# 200 deterministic points in the unit square: enough for real sparsity with a
+# small support radius, small enough for exact dense comparison.
+csrbfPoints = permutedims(reduce(vcat,
+    [mod(0.618034 * i, 1.0)  mod(0.414214 * i, 1.0)] for i in 1:200))
+csrbfData = vec(sin.(2π .* csrbfPoints[1, :]) .* cos.(π .* csrbfPoints[2, :]))
+csrbfKernel = Wendland(2, 1; ε = 4.0)   # support radius 0.25 ⇒ genuinely sparse
+
+@testset "Compact-support sparse RBF" begin
+
+    @testset "Assembly matches dense matrix" begin
+        tree = ScatteredInterpolation.NearestNeighbors.KDTree(csrbfPoints, Euclidean())
+        A = ScatteredInterpolation.assemblesparse(
+            csrbfKernel, csrbfPoints, tree, Euclidean(), false)
+        @test A isa ScatteredInterpolation.SparseArrays.SparseMatrixCSC
+        Adense = csrbfKernel.(Distances.pairwise(Euclidean(), csrbfPoints, dims = 2))
+        @test Matrix(A) ≈ Adense atol = 1e-12
+        # Actually sparse: with support radius 0.25 most pairs are beyond range.
+        @test ScatteredInterpolation.SparseArrays.nnz(A) < 0.5 * length(Adense)
+
+        # Scalar and vector smoothing land on the diagonal only.
+        As = ScatteredInterpolation.assemblesparse(
+            csrbfKernel, csrbfPoints, tree, Euclidean(), 0.1)
+        @test Matrix(As) ≈ Adense + 0.1 * I atol = 1e-12
+        sv = collect(range(0.01, 0.2; length = size(csrbfPoints, 2)))
+        Av = ScatteredInterpolation.assemblesparse(
+            csrbfKernel, csrbfPoints, tree, Euclidean(), sv)
+        @test Matrix(Av) ≈ Adense + Diagonal(sv) atol = 1e-12
+    end
+
+    @testset "Sparse weights match dense weights" begin
+        tree = ScatteredInterpolation.NearestNeighbors.KDTree(csrbfPoints, Euclidean())
+        itp = ScatteredInterpolation.interpolatecsrbf(
+            csrbfKernel, csrbfPoints, csrbfData, tree, Euclidean(), false, nothing, false)
+        @test itp isa ScatteredInterpolation.CompactSupportRBFInterpolant
+        dense = interpolate(csrbfKernel, csrbfPoints, csrbfData)
+        @test itp.w ≈ dense.w atol = 1e-8
+
+        # returnRBFmatrix hands back the assembled sparse matrix.
+        itp2, A = ScatteredInterpolation.interpolatecsrbf(
+            csrbfKernel, csrbfPoints, csrbfData, tree, Euclidean(), false, nothing, true)
+        @test A isa ScatteredInterpolation.SparseArrays.SparseMatrixCSC
+        @test itp2.w ≈ itp.w
+
+        # Matrix-valued samples: one solve per column.
+        multi = [csrbfData 2 .* csrbfData]
+        itpm = ScatteredInterpolation.interpolatecsrbf(
+            csrbfKernel, csrbfPoints, multi, tree, Euclidean(), false, nothing, false)
+        @test itpm.w[:, 2] ≈ 2 .* itpm.w[:, 1] atol = 1e-8
+    end
+end

--- a/test/csrbf.jl
+++ b/test/csrbf.jl
@@ -88,9 +88,11 @@ csrbfKernel = Wendland(2, 1; ε = 4.0)   # support radius 0.25 ⇒ genuinely spa
         @test evaluate(itpS, grid) ≈ evaluate(itpD, grid) atol = 1e-8
 
         # :auto — big n, small support ⇒ sparse; small n ⇒ dense; huge support ⇒ dense.
-        @test interpolate(w4, bigPoints, bigData) isa
+        # ε = 8 gives ~5% fill at n = 600, well under the calibrated SPARSE_MAX_FILL.
+        w8 = Wendland(2, 1; ε = 8.0)
+        @test interpolate(w8, bigPoints, bigData) isa
             ScatteredInterpolation.CompactSupportRBFInterpolant
-        @test interpolate(w4, csrbfPoints, csrbfData) isa
+        @test interpolate(w8, csrbfPoints, csrbfData) isa
             ScatteredInterpolation.RBFInterpolant
         @test interpolate(Wendland(2, 1; ε = 0.1), bigPoints, bigData) isa
             ScatteredInterpolation.RBFInterpolant   # support radius 10 ⇒ full matrix

--- a/test/pum.jl
+++ b/test/pum.jl
@@ -172,7 +172,7 @@ end
 
     @testset "Exactness with kernel $(typeof(kernel))" for kernel in (
             Gaussian(2), InverseMultiquadratic(2),
-            GeneralizedMultiquadratic(1, 1/2, 2), Wendland(2, 1))
+            GeneralizedMultiquadratic(1, 1/2, 2), Wendland(2, 1; ε = 1))
         pts = kroneckerpoints(2, 300)
         vals = [prod(sinpi, x) for x in eachcol(pts)]
         itp = interpolate(PartitionOfUnity(kernel; pointsperpatch = 60), pts, vals)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using ScatteredInterpolation, Test, LinearAlgebra, LinearSolve, IterativeSolvers
 # Import metrics explicitly: `using Distances` would also bring in `Distances.evaluate`,
 # which clashes with `ScatteredInterpolation.evaluate` and shadows it out of scope.
 using Distances: Cityblock, Euclidean, Haversine
+import Distances
 
 # Deterministic, RNG-free perturbation used by the interpolation tests. Using a fixed
 # pattern instead of `randn` keeps the "evaluate near a sample point" checks reproducible
@@ -16,6 +17,7 @@ perturbation(sz; scale = 5e-4) = reshape([scale * sinpi((2i + 1) / 7) for i in 1
     include("idw.jl")
     include("nearestNeighbor.jl")
     include("wendland.jl")
+    include("csrbf.jl")
     include("rippa.jl")
     include("pum.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using ScatteredInterpolation, Test, LinearAlgebra, LinearSolve, IterativeSolvers
 
 # Import metrics explicitly: `using Distances` would also bring in `Distances.evaluate`,
 # which clashes with `ScatteredInterpolation.evaluate` and shadows it out of scope.
-using Distances: Cityblock, Euclidean
+using Distances: Cityblock, Euclidean, Haversine
 
 # Deterministic, RNG-free perturbation used by the interpolation tests. Using a fixed
 # pattern instead of `randn` keeps the "evaluate near a sample point" checks reproducible

--- a/test/wendland.jl
+++ b/test/wendland.jl
@@ -21,7 +21,7 @@ wendlandData = [0.0, 0.5, 0.5, 1.0, 0.5, 0.3]
         # For dim ∈ {2, 3}, degree 1 is the classic C² Wendland function
         # ϕ(r) = (1 - r)₊⁴ (4r + 1).
         for dim in (2, 3)
-            w = Wendland(dim, 1)
+            w = Wendland(dim, 1; ε = 1)
             @test w(0.0) ≈ 1.0
             @test w(0.3) ≈ (1 - 0.3)^4 * (4 * 0.3 + 1)
             @test w(0.5) ≈ 0.5^4 * 3.0
@@ -32,14 +32,14 @@ wendlandData = [0.0, 0.5, 0.5, 1.0, 0.5, 0.3]
 
     @testset "Support radius and ε scaling" begin
         @test ScatteredInterpolation.support_radius(Wendland(2, 1; ε = 2)) ≈ 0.5
-        @test ScatteredInterpolation.support_radius(Wendland(2, 1)) ≈ 1.0
+        @test ScatteredInterpolation.support_radius(Wendland(2, 1; ε = 1)) ≈ 1.0
         for rbf in (Gaussian(2), Multiquadratic(2), InverseQuadratic(2),
                     InverseMultiquadratic(2), Polyharmonic(3), ThinPlate(),
                     GeneralizedMultiquadratic(1, 1/2, 2), GeneralizedPolyharmonic(3, 2))
             @test ScatteredInterpolation.support_radius(rbf) == Inf
         end
         # ε rescales the argument: ϕ_ε(r) = ϕ(εr)
-        @test Wendland(3, 1; ε = 2)(0.25) ≈ Wendland(3, 1)(0.5)
+        @test Wendland(3, 1; ε = 2)(0.25) ≈ Wendland(3, 1; ε = 1)(0.5)
         @test Wendland(3, 1; ε = 2)(0.6) == 0.0
     end
 
@@ -55,7 +55,7 @@ wendlandData = [0.0, 0.5, 0.5, 1.0, 0.5, 0.3]
     end
 
     @testset "Wendland shape parameter traits" begin
-        @test ScatteredInterpolation.hasshape(Wendland(2, 1))
+        @test ScatteredInterpolation.hasshape(Wendland(2, 1; ε = 1))
         w = ScatteredInterpolation.withshape(Wendland(3, 2; ε = 2), 4.0)
         @test w isa Wendland
         @test w.ε == 4.0
@@ -63,5 +63,41 @@ wendlandData = [0.0, 0.5, 0.5, 1.0, 0.5, 0.3]
         ref = Wendland(3, 2; ε = 4)
         @test all(w(r) ≈ ref(r) for r in 0:0.05:0.3)
         @test ScatteredInterpolation.support_radius(w) ≈ 0.25
+    end
+
+    @testset "Deferred shape parameter" begin
+        w = Wendland(2, 1)
+        @test w.ε === nothing
+        @test_throws ArgumentError w(0.3)
+        @test_throws ArgumentError ScatteredInterpolation.support_radius(w)
+
+        # 1D grid, spacing 0.1: with neighbors = 2 the k-NN query takes k = 3 points
+        # (the point itself plus its two neighbors at ±0.1), so the k-th-neighbor
+        # distance is 0.1 for every interior point and the median support radius is
+        # r = 0.1, i.e. ε = 10.
+        gridPoints = collect(0.0:0.1:10.0)'
+        resolved, tree = ScatteredInterpolation.resolveshape(
+            Wendland(1, 1), gridPoints, Euclidean(), 2)
+        @test resolved isa Wendland
+        @test resolved.ε ≈ 10.0 rtol = 0.01
+        @test tree isa ScatteredInterpolation.NearestNeighbors.KDTree
+
+        # Explicit ε passes through untouched, no tree built.
+        passthrough, notree = ScatteredInterpolation.resolveshape(
+            Wendland(1, 1; ε = 3), gridPoints, Euclidean(), 2)
+        @test passthrough.ε == 3
+        @test notree === nothing
+
+        # Non-Minkowski metric cannot drive the KDTree.
+        @test_throws ArgumentError ScatteredInterpolation.resolveshape(
+            Wendland(2, 1), wendlandPoints, Haversine(), 2)
+
+        # All-duplicate points give a zero radius.
+        dupPoints = zeros(2, 20)
+        @test_throws ArgumentError ScatteredInterpolation.resolveshape(
+            Wendland(2, 1), dupPoints, Euclidean(), 2)
+
+        @test_throws ArgumentError ScatteredInterpolation.resolveshape(
+            Wendland(2, 1), gridPoints, Euclidean(), 0)
     end
 end


### PR DESCRIPTION
## Summary
- Add a sparse interpolation path for compactly supported RBFs (Wendland): KDTree range queries assemble only nonzero entries into a `SparseMatrixCSC`, solved with CHOLMOD via LinearSolve.jl
- `interpolate` gains `sparse` (`:auto`/`true`/`false`) and `neighbors` (data-driven ε resolution) kwargs; `Wendland(dim, degree)` without explicit ε is now valid and resolved from the training data
- Assembly and evaluation are threaded via OhMyThreads (`index_chunks` + `tmap`), matching the existing PUM pattern
- Sparse path is 43× faster than dense at n=10k with low fill; `:auto` routing calibrated from benchmark (crossover at ~7% fill)

## Changes
- `src/wendland.jl`: Deferred ε support, `resolveshape` for data-driven resolution
- `src/csrbf.jl` (new): `CompactSupportRBFInterpolant`, sparse assembly/solve/evaluate, routing logic (`decidesparse`, `sparseineligibility`, `estimatefill`)
- `src/rbf.jl`: `sparse`/`neighbors` kwargs on `interpolate`, routing to sparse path
- `docs/src/methods.md`: Kernel-support table, scipy distinction, accuracy/sparsity trade-offs
- `test/csrbf.jl` (new): 200-point deterministic test data, assembly/weights/evaluation/routing tests

## Test plan
- [x] All 432 tests pass
- [x] Sparse vs dense matrix equality (atol=1e-12)
- [x] Sparse vs dense weights and evaluation agreement (atol=1e-8)
- [x] Routing: `:auto`/`true`/`false`, ineligibility errors with PartitionOfUnity pointer
- [x] Deferred ε through `interpolate`, `neighbors` kwarg
- [x] Complex samples, CG solver override, smooth forwarding, returnRBFmatrix
- [x] Threading: 12 threads, results identical to serial

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jZaxELZbHCL5fKz9WeYk4